### PR TITLE
Support for Processing 3

### DIFF
--- a/pan_zoom/PanZoomController.java
+++ b/pan_zoom/PanZoomController.java
@@ -30,7 +30,7 @@ import processing.core.PVector;
  * }
  * void draw() {
  *   PVector pan = panZoomController.getPan();
- *   pushMatrix();  
+ *   pushMatrix();
  *   translate(pan.x, pan.y);
  *   scale(panZoomController.getScale());
  *   // draw ...
@@ -41,6 +41,9 @@ import processing.core.PVector;
  * }
  * void mouseDragged() {
  *   panZoomController.mouseDragged();
+ * }
+ * void mouseWheel(MouseEvent event) {
+ *   panZoomController.mouseWheel(event.getCount());
  * }
  * }
  * </pre>
@@ -65,11 +68,6 @@ public class PanZoomController {
 
 	public PanZoomController(PApplet p) {
 		this.p = p;
-		p.addMouseWheelListener(new MouseWheelListener() {
-			public void mouseWheelMoved(MouseWheelEvent event) {
-				mouseWheel(event.getWheelRotation());
-			}
-		});
 	}
 
 	public void mouseDragged() {
@@ -97,7 +95,7 @@ public class PanZoomController {
 		}
 	}
 
-	private void mouseWheel(int step) {
+	public void mouseWheel(int step) {
 		logScale = PApplet.constrain(logScale + step * scaleVelocity,
 			minLogScale,
 			maxLogScale);

--- a/pan_zoom/pan_zoom.pde
+++ b/pan_zoom/pan_zoom.pde
@@ -88,3 +88,6 @@ void mouseDragged() {
   panZoomController.mouseDragged();
 }
 
+void mouseWheel(MouseEvent event) {
+  panZoomController.mouseWheel(event.getCount());
+}


### PR DESCRIPTION
With Processing 3, the `PApplet` class does not longer inherit `java.awt.Applet`, which deprecates the need of a `MouseWheelListener`.
